### PR TITLE
Make more venv-friendly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,11 @@ CC_CHECK += -m32
 
 
 CPP             := cpp
-ELF2ROM         ?= ./tools/elf2rom
-MKLDSCRIPT      ?= ./tools/mkldscript
-DISASSEMBLER    ?= ./tools/py_mips_disasm/simpleDisasm.py
-ASM_PROCESSOR   ?= python3 tools/asm_processor/build.py
+PYTHON          := python3
+ELF2ROM         ?= tools/elf2rom
+MKLDSCRIPT      ?= tools/mkldscript
+DISASSEMBLER    ?= $(PYTHON) tools/py_mips_disasm/simpleDisasm.py
+ASM_PROCESSOR   ?= $(PYTHON) tools/asm_processor/build.py
 
 ASMPROCFLAGS := 
 OPTFLAGS := -O2
@@ -178,12 +179,12 @@ asmclean:
 ## Extraction step
 setup:
 	$(MAKE) -C tools
-	./decompress_baserom.py $(GAME) $(VERSION)
-	./extract_baserom.py $(GAME) $(VERSION)
+	$(PYTHON) decompress_baserom.py $(GAME) $(VERSION)
+	$(PYTHON) extract_baserom.py $(GAME) $(VERSION)
 
 ## Assembly generation
 disasm: splitcsvs $(DISASM_TARGETS)
-	./tools/automators/gen_undefined_syms.py --version $(VERSION) > $(BASE_DIR)/undefined_syms_$(VERSION).txt
+	$(PYTHON) tools/automators/gen_undefined_syms.py --version $(VERSION) > $(BASE_DIR)/undefined_syms_$(VERSION).txt
 	@echo "Disassembly done!"
 
 splitcsvs: $(CSV_FILES)
@@ -196,10 +197,10 @@ diff-init: uncompressed
 #### Various Recipes ####
 
 $(BASE_DIR)/tables/%.csv: $(GAME)/tables/%.csv
-	./tools/csvSplit.py $(GAME) $<
+	$(PYTHON) tools/csvSplit.py $(GAME) $<
 
 $(BASE_DIR)/tables/files_%.csv: $(GAME)/tables/%.*.csv
-	./tools/csvSplit.py $(GAME) $<
+	$(PYTHON) tools/csvSplit.py $(GAME) $<
 
 ## Linker Scripts
 $(BASE_DIR)/build/undefined_syms_$(VERSION).txt: $(BASE_DIR)/undefined_syms_$(VERSION).txt

--- a/extract_baserom.py
+++ b/extract_baserom.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from __future__ import annotations
 

--- a/fixbaserom.py
+++ b/fixbaserom.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from os import path
 import argparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+libyaz0>=0.5
 sortedcontainers>=2.4.0

--- a/tools/csvSplit.py
+++ b/tools/csvSplit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from __future__ import annotations
 

--- a/tools/mips/MipsSplitEntry.py
+++ b/tools/mips/MipsSplitEntry.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 from __future__ import annotations
 
 from py_mips_disasm.backend.common.Utils import *

--- a/tools/vt_fmt.py
+++ b/tools/vt_fmt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
Ideally all Python executable files should use `#!/usr/bin/env python3`, but I didn't want to change `tools/py_mips_disasm/simpleDisasm.py` because it's in a subrepo, so I settled for explicitly running `python3` in the Makefile instead